### PR TITLE
fix IsCursorInTaskbar() when taskbar is at top, left or right.

### DIFF
--- a/Classes/Helpers/Taskbar.cs
+++ b/Classes/Helpers/Taskbar.cs
@@ -97,17 +97,10 @@ namespace tb_vol_scroll.Classes.Helpers
             GetWindowRect(hWnd, out Rectangle shellTrayArea);
 
             bool cursorIsInTaskbarAreaAndTaskbarIsVisible = (className == "Shell_TrayWnd" || className == "Shell_SecondaryTrayWnd");
-            bool cursorIsInTaskbarAreaOnly = false;
-            if (Settings.Default.IgnoreTaskbarVisibility)
-            {
-                int taskbarHeight = shellTrayArea.Height - shellTrayArea.Y;
-                Rectangle workingArea = screen.Bounds;
-                workingArea.Height -= taskbarHeight;
-                if (!workingArea.Contains(position))
-                    cursorIsInTaskbarAreaOnly = true;
-            }
-            else
-                cursorIsInTaskbarAreaOnly = shellTrayArea.Contains(position);
+
+            bool cursorIsInTaskbarAreaOnly = // which .Width is X2, .Height is Y2
+                shellTrayArea.X < position.X && position.X < shellTrayArea.Width
+                && shellTrayArea.Y < position.Y && position.Y < shellTrayArea.Height;
 
             if (Settings.Default.IgnoreTaskbarVisibility)
                 return cursorIsInTaskbarAreaOnly;


### PR DESCRIPTION
Hi @dvingerh , 

My taskbars are on the right sides for my 2 monitors. 
I set Settings.Default.IgnoreTaskbarVisibility true.

The current IsCursorInTaskbar() calculation assumes the taskbar is at the bottom. As a result, mousewheel scrolling anywhere of my whole screen triggers volume up/down.

If you confirm this bug, consider my proposed fix.
I have tested on win10 and win11(with https://github.com/valinet/ExplorerPatcher so taskbars can be moved)

thanks.